### PR TITLE
Fix for esp-idf v5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS "mongoose/mongoose.c"
                        INCLUDE_DIRS "mongoose"
-                       REQUIRES lwip mbedtls)
+                       REQUIRES lwip mbedtls esp_timer)
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE MG_ENABLE_MBEDTLS=1)


### PR DESCRIPTION
In esp-idf version 5.0, the components requirements need to explicitly contain `esp_timer`. This PR adds the missing dependency.

Tested with esp-idf version 4.4 and 5.0